### PR TITLE
Move images to autopilotpattern repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# triton-cloudflare
+# CloudFlare autopilot pattern
 
 *Automatically update a Cloudflare DNS when a containerized service's IPs change*
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -16,7 +16,7 @@ consul:
     restart: always
 
 nginx:
-    image: 0x74696d/triton-cloudflare-demo-nginx
+    image: autopilotpattern/cloudflare-demo-nginx
     mem_limit: 512m
     ports:
     - 80
@@ -30,7 +30,7 @@ nginx:
       nginx -g "daemon off;"
 
 cloudflare:
-    image: 0x74696d/triton-cloudflare
+    image: autopilotpattern/cloudflare
     mem_limit: 128m
     links:
     - consul:consul

--- a/example/makefile
+++ b/example/makefile
@@ -14,10 +14,10 @@ build: .env build/containerbuddy
 	docker-compose -f docker-compose-local.yml build
 
 ship:
-	docker tag -f tritoncloudflare_nginx 0x74696d/triton-cloudflare-demo-nginx
-	docker tag -f tritoncloudflare_cloudflare 0x74696d/triton-cloudflare
-	docker push 0x74696d/triton-cloudflare-demo-nginx
-	docker push 0x74696d/triton-cloudflare
+	docker tag -f tritoncloudflare_nginx autopilotpattern/cloudflare-demo-nginx
+	docker tag -f tritoncloudflare_cloudflare autopilotpattern/cloudflare
+	docker push autopilotpattern/cloudflare-demo-nginx
+	docker push autopilotpattern/cloudflare
 
 #------------------------------------
 # get latest build of containerbuddy and copy to Docker build contexts


### PR DESCRIPTION
@misterbisson this updates the repo to have container images moved under the autopilotpattern org.

The new images have been pushed to:
https://hub.docker.com/r/autopilotpattern/cloudflare/
https://hub.docker.com/r/autopilotpattern/cloudflare-demo-nginx/
